### PR TITLE
feat: add touch method to update model's timestamp

### DIFF
--- a/src/Data/Concerns/DatabaseWritable.php
+++ b/src/Data/Concerns/DatabaseWritable.php
@@ -229,7 +229,7 @@ trait DatabaseWritable
      *
      * @return bool
      */
-    public function refreshTimestamp(): bool
+    public function touch(): bool
     {
         $this->updateTimestamps();
         return $this->performUpdate();

--- a/src/Data/Concerns/DatabaseWritable.php
+++ b/src/Data/Concerns/DatabaseWritable.php
@@ -223,4 +223,15 @@ trait DatabaseWritable
     {
         return !empty($this->dirty);
     }
+
+    /**
+     * Update model's timestamp
+     *
+     * @return bool
+     */
+    public function refreshTimestamp(): bool
+    {
+        $this->updateTimestamps();
+        return $this->performUpdate();
+    }
 }


### PR DESCRIPTION
### Summary
This pull request introduces the `touch` method to the `DatabaseWritable` trait. The method is used to refresh the `updated_at` timestamp of a model without making any other changes to it. This is useful when you want to update the timestamp without modifying other fields in the record.

### Changes:
- Added the `touch` method to the `DatabaseWritable` trait.
- It updates the timestamps and performs an update operation.