### PR TITLE
fix: sqlite query adapter

### DIFF
--- a/src/Data/Adapters/SQLiteAdapter.php
+++ b/src/Data/Adapters/SQLiteAdapter.php
@@ -59,7 +59,7 @@ class SQLiteAdapter implements ConnectionAdapterInterface
     {
         $stmt = $this->prepare($sql);
         $stmt->execute($bindings);
-        return $stmt->fetchAll();
+        return $stmt;
     }
 
     public function exec(string $sql, array $bindings = []): void


### PR DESCRIPTION
Change query method to return statement object instead of all results.